### PR TITLE
correct url in manifest.json

### DIFF
--- a/limitPosts.js
+++ b/limitPosts.js
@@ -189,6 +189,7 @@ function waitFor(selector) {
 
 browser.storage.local.get("xPostLimitNum").then((result) => {
     LIMIT = result.xPostLimitNum || LIMIT;
+    console.log(`Retrieved the limit value from storage: ${LIMIT}`);
     waitFor('div[aria-label="Home timeline"]');
 });
 
@@ -199,3 +200,5 @@ browser.storage.onChanged.addListener((changes, area) => {
         LIMIT = changes.xPostLimitNum.newValue;
     };
 });
+
+console.log('This line is being run!');

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,9 @@
     
     "content_scripts": [
         {
-            "matches": ["*://*.x.com/home"],
+            "matches": [
+                "*://*.x.com/*", 
+                "*://*.twitter.com/*"],
             "js": ["limitPosts.js"]
         }
     ],
@@ -16,7 +18,7 @@
         "storage",
         "activeTab"
     ],
-    
+
     "browser_action": {
         "default_title": "X Scroll limiter",
         "default_popup": "popup/select_options.html"


### PR DESCRIPTION
fixes: https://github.com/sanivada/DisableDoomScrollingTwitter-BrowserExtensionFirefox/issues/6

The change is simple, change the url matches in manifest.json from "*://*.x.com/home" to "*://*.x.com/*".

The problem was that when an user enters x.com on their address bar, twitter redirects to x.com/home but browser does not load the extension script because the user entered url does not match the one specified in manifest.json